### PR TITLE
Fixed typo in newFolderPicker.js

### DIFF
--- a/src/newFolderPicker.js
+++ b/src/newFolderPicker.js
@@ -95,7 +95,7 @@ class NewFolderPicker extends MultiStepPicker {
   }
 
   setTitle(filepath) {
-    this.picker.title = `Create a new file: "${filepath}"`;
+    this.picker.title = `Create a new folder: "${filepath}"`;
   }
 }
 


### PR DESCRIPTION
Hi I am enjoying the extension.

When you create a new folder then the title says create new file instead of folder, I think I fixed the problem.

Greetings Ferenc.